### PR TITLE
fix: handle async params in study page using React.use()

### DIFF
--- a/src/app/study/[deckId]/page.tsx
+++ b/src/app/study/[deckId]/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { use } from 'react';
 import FlashcardContainer from '@/components/features/study/FlashcardContainer'
 
 // This is temporary sample data - will be replaced with actual data from API
@@ -22,15 +23,27 @@ const sampleCards = [
 ]
 
 interface StudyPageProps {
-  params: {
+  params: Promise<{
     deckId: string
-  }
+  }>
 }
 
 export default function StudyPage({ params }: StudyPageProps) {
+  const { deckId } = use(params);
+
+  if (!deckId) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="bg-red-50 border border-red-200 rounded-md p-4 text-red-600">
+          Deck ID not found
+        </div>
+      </div>
+    );
+  }
+
   return (
     <FlashcardContainer 
-      deckId={params.deckId}
+      deckId={deckId}
       cards={sampleCards}
     />
   )


### PR DESCRIPTION
# Fix Async Params Handling in Study Page

## Problem
The study page was throwing an error when accessing `params.deckId` directly because in Next.js App Router, `params` is now a Promise in client components. The error indicated that we need to properly unwrap the params using `React.use()`.

Error message:
```
Error: A param property was accessed directly with params.deckId. params is now a Promise and should be unwrapped with React.use() before accessing properties of the underlying params object.
```

## Solution
- Added `use()` hook from React to properly handle async params
- Updated TypeScript types to reflect params as a Promise
- Added fallback UI for cases where deckId is missing
- Maintained existing functionality while making it future-proof

## Changes
- Imported `use` from React
- Updated StudyPageProps interface to type params as a Promise
- Unwrapped params using `use()` hook before accessing deckId
- Added error handling for missing deckId
- Updated component to use unwrapped deckId

## Testing
To test this change:
1. Navigate to any study page (e.g., `/study/1`)
2. Verify no console errors about params access
3. Verify deck content loads correctly
4. Test with invalid deck ID to ensure error handling works

## Impact
This change:
- ✅ Fixes the immediate error with params access
- ✅ Prepares the code for future Next.js versions
- ✅ Improves error handling
- ✅ Maintains type safety

## Additional Notes
This is a forward-compatible change that aligns with Next.js best practices for handling dynamic params in client components.